### PR TITLE
Small Idea

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -409,6 +409,12 @@ int Search::pvs(std::int16_t alpha, std::int16_t beta, std::int16_t depth, std::
             continue;
         }
 
+        // Idea
+        if (!pvNode && bestScore > -infinity && moveCounter >= 3 * depth && staticEval < alpha - 500)
+        {
+            continue;
+        }
+
         // Late move prunning
         if (!pvNode && isQuiet && bestScore > -infinity && moveCounter > (6 + 2 * depth * depth) && depth <= 3)
         {


### PR DESCRIPTION
```Elo   | 12.89 +- 6.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3802 W: 1082 L: 941 D: 1779
Penta | [44, 418, 863, 505, 71]```
<https://chess.aronpetkovski.com/test/8887/>

```Elo   | 5.46 +- 3.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9672 W: 2452 L: 2300 D: 4920
Penta | [59, 1118, 2353, 1224, 82]```
<https://chess.aronpetkovski.com/test/8888/>

Bench 3440872