### PR TITLE
Simplify Razoring

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -132,8 +132,7 @@ int Search::pvs(int alpha, int beta, int depth, const int ply, Board &board, boo
 
     // Razoring
     if (!isSingularSearch && !pvNode && !inCheck && depth < 3 && staticEval + 175 * depth < alpha) {
-        const int score = qs(alpha, beta, board, ply);
-        if (score < alpha) {
+        if (const int score = qs(alpha, beta, board, ply); score < alpha) {
             return score;
         }
     }


### PR DESCRIPTION
Elo   | 4.03 +- 4.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7580 W: 1971 L: 1883 D: 3726
Penta | [79, 900, 1752, 972, 87]
https://furybench.com/test/3335/